### PR TITLE
Remove duplicate address update promise

### DIFF
--- a/docs/Account.html
+++ b/docs/Account.html
@@ -617,7 +617,7 @@ emits an update that can be subscribed to with onWebsocketUpdate</p>
     <dd class="tag-source">
       <ul class="dummy">
         <li>
-          <a href="Account.js.html">Account.js</a>, <a href="Account.js.html#line636">line 636</a>
+          <a href="Account.js.html">Account.js</a>, <a href="Account.js.html#line635">line 635</a>
         </li>
       </ul>
     </dd>
@@ -714,7 +714,7 @@ emits an update that can be subscribed to with onWebsocketUpdate</p>
     <dd class="tag-source">
       <ul class="dummy">
         <li>
-          <a href="Account.js.html">Account.js</a>, <a href="Account.js.html#line625">line 625</a>
+          <a href="Account.js.html">Account.js</a>, <a href="Account.js.html#line624">line 624</a>
         </li>
       </ul>
     </dd>
@@ -866,7 +866,7 @@ emits an update that can be subscribed to with onWebsocketUpdate</p>
     <dd class="tag-source">
       <ul class="dummy">
         <li>
-          <a href="Account.js.html">Account.js</a>, <a href="Account.js.html#line576">line 576</a>
+          <a href="Account.js.html">Account.js</a>, <a href="Account.js.html#line575">line 575</a>
         </li>
       </ul>
     </dd>
@@ -1016,7 +1016,7 @@ account.discoverChain(0).then((acc) => {
     <dd class="tag-source">
       <ul class="dummy">
         <li>
-          <a href="Account.js.html">Account.js</a>, <a href="Account.js.html#line603">line 603</a>
+          <a href="Account.js.html">Account.js</a>, <a href="Account.js.html#line602">line 602</a>
         </li>
       </ul>
     </dd>
@@ -3398,7 +3398,7 @@ var addresses = account.getUsedAddresses(0)
     <dd class="tag-source">
       <ul class="dummy">
         <li>
-          <a href="Account.js.html">Account.js</a>, <a href="Account.js.html#line655">line 655</a>
+          <a href="Account.js.html">Account.js</a>, <a href="Account.js.html#line654">line 654</a>
         </li>
       </ul>
     </dd>

--- a/docs/Account.js.html
+++ b/docs/Account.js.html
@@ -615,14 +615,13 @@ class Account {
     for (let addr of addresses) {
       let address = new Address(addr, coin, false)
 
-      let prom = address.updateState()
+      let addressUpdatePromise = address.updateState()
 
       // This will only be called for any rejections AFTER the first one,
       // please take a look at the comment below for more info.
-      prom.catch((e) => {
-      })
+      addressUpdatePromise.catch((e) => { console.warn(`An Address Discovery Promise failed during Account Discovery! ${e}\n${e.stack}`) })
 
-      addressPromises.push(address.updateState())
+      addressPromises.push(addressUpdatePromise.updateState())
     }
 
     let promiseResponses = []
@@ -634,7 +633,7 @@ class Account {
       // The first promise rejection will be caught here, all other promises
       // that reject AFTER the first, will be caught in the above prom.catch() function.
 
-      throw new Error('Unable to update Address state in _chainPromise \n' + e)
+      throw new Error(`Account Discovery failure in _chainPromise! ${e}\n${e.stack}`)
     }
 
     for (let address of promiseResponses) {

--- a/src/Account.js
+++ b/src/Account.js
@@ -522,14 +522,13 @@ class Account {
     for (let addr of addresses) {
       let address = new Address(addr, coin, false)
 
-      let prom = address.updateState()
+      let addressUpdatePromise = address.updateState()
 
       // This will only be called for any rejections AFTER the first one,
       // please take a look at the comment below for more info.
-      prom.catch((e) => {
-      })
+      addressUpdatePromise.catch((e) => { console.warn(`An Address Discovery Promise failed during Account Discovery! ${e}\n${e.stack}`) })
 
-      addressPromises.push(address.updateState())
+      addressPromises.push(addressUpdatePromise)
     }
 
     let promiseResponses = []
@@ -541,7 +540,7 @@ class Account {
       // The first promise rejection will be caught here, all other promises
       // that reject AFTER the first, will be caught in the above prom.catch() function.
 
-      throw new Error('Unable to update Address state in _chainPromise \n' + e)
+      throw new Error(`Account Discovery failure in _chainPromise! ${e}\n${e.stack}`)
     }
 
     for (let address of promiseResponses) {


### PR DESCRIPTION
There is currently a bug that duplicates the address update request, causing duplicate network requests.